### PR TITLE
tools: support Verilator 5.x and add per-test VCD dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ obj_dir
 *.log
 *.exe
 *.swp
+.program_hex_test

--- a/testbench/test_tb_top.cpp
+++ b/testbench/test_tb_top.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include <stdlib.h>
+#include <cstring>
 #include <iostream>
 #include <utility>
 #include <string>
@@ -43,7 +44,15 @@ int main(int argc, char** argv) {
   Verilated::traceEverOn(true);
   tfp = new VerilatedVcdC;
   tb->trace (tfp, 24);
-  tfp->open ("sim.vcd");
+  // VCD output file name. Defaults to sim.vcd; override at runtime with
+  // +vcdfile=<name> (the Makefile passes +vcdfile=$(TEST).vcd on debug=1).
+  std::string vcdname = "sim.vcd";
+  const char* vcdarg = Verilated::commandArgsPlusMatch("vcdfile=");
+  if (vcdarg && vcdarg[0]) {
+    const char* eq = strchr(vcdarg, '=');
+    if (eq && eq[1]) vcdname = eq + 1;
+  }
+  tfp->open (vcdname.c_str());
 #endif
   // Simulate
   while(!Verilated::gotFinish()){

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -38,6 +38,9 @@ IRUN = xrun
 VCS = vcs
 VLOG = qverilog
 VERILATOR = verilator
+# Warnings to suppress for the Verilator build. -Wno-STMTDLY is required for
+# Verilator >= 5.x, which promotes the #delay in SimJTAG.v to a fatal error.
+VERILATOR_WARN = -Wno-WIDTH -Wno-UNOPTFLAT -Wno-IMPLICIT -Wno-STMTDLY
 RIVIERA = riviera
 GCC_PREFIX = riscv64-unknown-elf
 BUILD_DIR = snapshots/${snapshot}
@@ -64,6 +67,9 @@ ifdef debug
  IRUN_DEBUG_RUN = -input ${RV_ROOT}/testbench/input.tcl
  VCS_DEBUG = -debug_access
  VERILATOR_DEBUG = --trace
+ # Name the Verilator VCD after the test so each run dumps <TEST>.vcd
+ # (e.g. dhry.vcd) into the working dir instead of a generic sim.vcd.
+ VERILATOR_RUN_ARGS = +vcdfile=$(TEST).vcd
  RIVIERA_DEBUG = +access +r
 endif
 
@@ -102,7 +108,7 @@ clean:
 	rm -rf *.log *.s *.hex *.dis *.tbl irun* vcs* simv* snapshots veer* \
 	verilator* *.map *.exe obj* *.o ucli.key vc_hdrs.h csrc *.csv \
 	work dataset.asdb  library.cfg vsimsa.cfg  riviera-build wave.asdb \
-	SimJTAG.so
+	SimJTAG.so .program_hex_test
 
 
 
@@ -116,8 +122,8 @@ verilator-build: ${TBFILES} ${BUILD_DIR}/defines.h test_tb_top.cpp
 	echo '`undef RV_ASSERT_ON' >> ${BUILD_DIR}/common_defines.vh
 	$(VERILATOR)  --cc -CFLAGS ${CFLAGS} $(defines) \
 	  $(includes) -I${RV_ROOT}/testbench -f ${RV_ROOT}/testbench/flist \
-	  -Wno-WIDTH -Wno-UNOPTFLAT -Wno-IMPLICIT ${TBFILES} --top-module tb_top \
-	  -exe test_tb_top.cpp --autoflush $(VERILATOR_DEBUG)
+	  $(VERILATOR_WARN) ${TBFILES} --top-module tb_top \
+	  -exe test_tb_top.cpp --autoflush $(VERILATOR_DEBUG) --no-timing
 	$(MAKE) -j -C obj_dir -f Vtb_top.mk $(VERILATOR_MAKE_FLAGS)
 	touch verilator-build
 
@@ -151,7 +157,7 @@ riviera-build: ${TBFILES} ${BUILD_DIR}/defines.h ${RV_ROOT}/testbench/flist.rivi
 #################### TEST Simulation Run ###############################
 
 verilator: program.hex verilator-build
-	./obj_dir/Vtb_top $(run_arg)
+	./obj_dir/Vtb_top $(run_arg) $(VERILATOR_RUN_ARGS)
 
 irun: program.hex irun-build
 	$(IRUN) -64bit  +lic_queue -licqueue \
@@ -173,9 +179,15 @@ riviera: program.hex riviera-build SimJTAG.so
 #################### TEST Build #######################################
 
 ifeq ($(shell which $(GCC_PREFIX)-gcc 2> /dev/null),)
-program.hex: ${BUILD_DIR}/defines.h
-	@echo " !!! No $(GCC_PREFIX)-gcc in path, using canned hex files !!"
-	cp ${HEX_DIR}/$(TEST).hex program.hex
+# Canned hex files all share one mtime, so a normal prerequisite won't force a
+# re-copy when TEST changes. Use FORCE + a stamp of the last TEST so program.hex
+# is refreshed whenever the selected test differs from what was last copied.
+program.hex: ${BUILD_DIR}/defines.h FORCE
+	@if [ "$$(cat .program_hex_test 2> /dev/null)" != "$(TEST)" ] || [ ! -f program.hex ]; then \
+	  echo " !!! No $(GCC_PREFIX)-gcc in path, using canned hex files !!"; \
+	  cp ${HEX_DIR}/$(TEST).hex program.hex; \
+	  echo "$(TEST)" > .program_hex_test; \
+	fi
 else
 ifneq (,$(wildcard $(TEST_DIR)/$(TEST).makefile))
 program.hex:
@@ -206,4 +218,5 @@ help:
 	@echo Make sure the environment variable RV_ROOT is set.
 	@echo Possible targets: verilator vcs irun vlog riviera help clean all verilator-build irun-build vcs-build riviera-build program.hex
 
-.PHONY: help clean verilator vcs irun vlog riviera
+FORCE: ;
+.PHONY: help clean verilator vcs irun vlog riviera FORCE


### PR DESCRIPTION
## Summary

Three related fixes to the Verilator simulation flow in `tools/Makefile` (plus a small `testbench/test_tb_top.cpp` change), making `make -f tools/Makefile verilator` work out of the box with current Verilator and improving the canned-hex / waveform workflow.

## Changes

### 1. Verilator 5.x build compatibility
Verilator >= 5.x promotes the `#delay` in `testbench/SimJTAG.v` to a **fatal** `STMTDLY` error, breaking `verilator-build`. The existing inline `-Wno-...` list is factored into a `VERILATOR_WARN` variable with `-Wno-STMTDLY` added. (`--no-timing` on the build line is the companion flag covering the same timing constructs.)

### 2. Refresh canned hex when `TEST` changes
In the no-toolchain branch, `program.hex` depended only on `defines.h`, so switching `TEST` in an existing working directory silently reused the previous test's image — e.g. `TEST=dhry` would actually run `hello_world`. Because all bundled `.hex` files share one mtime, a plain prerequisite can't force the re-copy. Fixed with a `FORCE` prerequisite plus a `.program_hex_test` stamp, so the hex is re-copied only when the selected test differs.

### 3. Per-test VCD file names
With `debug=1`, the Verilator dump is now named after the test (`<TEST>.vcd`, e.g. `dhry.vcd`) instead of a generic `sim.vcd`, so dumps from different tests no longer clobber each other. The C++ harness reads the name from a `+vcdfile=` **runtime** plusarg (defaulting to `sim.vcd`) — chosen over a compile-time define because `verilator-build` is cached and a compile-time name would go stale across `TEST` changes.

Also: ignore the new `.program_hex_test` stamp in `.gitignore` and remove it on `make clean`.

## Testing
Verified with Verilator 5.020 (no RISC-V toolchain, using the bundled canned hex):

- `make -f tools/Makefile verilator TEST=hello_world` → `TEST_PASSED`
- `make -f tools/Makefile verilator TEST=cmark` → CoreMark validated, `TEST_PASSED`
- `make -f tools/Makefile verilator TEST=dhry` → Dhrystone runs (previously ran `hello_world` on a `TEST` switch)
- `make -f tools/Makefile verilator debug=1 TEST=dhry` → produces `dhry.vcd`; `TEST=hello_world` produces `hello_world.vcd`

Backwards compatible: with a RISC-V toolchain installed those code paths are untouched, and without `debug=1` no VCD is produced (the `+vcdfile` plusarg defaults to `sim.vcd` and is unused when tracing is off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
